### PR TITLE
docs: update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For example, this chat command:
 final ping = ChatCommand(
   'ping',
   'Ping the bot',
-  (IChatContext context) => context.respond(MessageBuilder.content('Pong!')),
+  (ChatContext context) => context.respond(MessageBuilder.content('Pong!')),
 );
 ```
 must have its callback wrapped with `id` like so:
@@ -41,7 +41,7 @@ must have its callback wrapped with `id` like so:
 final ping = ChatCommand(
   'ping',
   'Ping the bot',
-  id('ping', (IChatContext context) => context.respond(MessageBuilder.content('Pong!'))),
+  id('ping', (ChatContext context) => context.respond(MessageBuilder.content('Pong!'))),
 );
 ```
 
@@ -53,13 +53,13 @@ final ping = ChatCommand(
   id('ping', _ping),
 );
 
-void _ping(IChatContext context) =>
+void _ping(ChatContext context) =>
   context.respond(MessageBuilder.content('Pong!'));
 ```
 
 If you forget to add the `id` to a function, you'll get an error similar to this one:
 ```
-Error: Command Exception: Couldn't load function data for function Closure: (IChatContext) => Null
+Error: Command Exception: Couldn't load function data for function Closure: (ChatContext) => Null
 Stack trace:
 #0      loadFunctionData (package:nyxx_commands/src/mirror_utils/compiled.dart:18)
 #1      ChatCommand._loadArguments (package:nyxx_commands/src/commands/chat_command.dart:354)

--- a/example/example.dart
+++ b/example/example.dart
@@ -109,13 +109,13 @@ void main() async {
     // The first parameter to this function must be a `ChatContext`. A `ChatContext` allows you to access
     // various information about how the command was run: the user that executed it, the guild it
     // was ran in and a few other useful pieces of information.
-    // `IChatContext` also has a couple of methods that make it easier to respond to commands.
+    // `ChatContext` also has a couple of methods that make it easier to respond to commands.
     //
     // Since a ping command doesn't have any other arguments, we don't add any other parameters to
     // the function.
     id('ping', (ChatContext context) {
       // For a ping command, all we need to do is respond with `pong`.
-      // To do that, we can use the `IChatContext`'s `respond` method which responds to the command with
+      // To do that, we can use the `ChatContext`'s `respond` method which responds to the command with
       // a message.
       context.respond(MessageBuilder(content: 'pong!'));
     }),
@@ -488,7 +488,7 @@ void main() async {
   //
   // As an example:
   // ```dart
-  // (IChatContext context, [String? a, String? b, String? c]) {}
+  // (ChatContext context, [String? a, String? b, String? c]) {}
   // ```
   // In this case, `b` having a value does not guarantee `a` has a value.
 

--- a/lib/src/checks/checks.dart
+++ b/lib/src/checks/checks.dart
@@ -104,7 +104,7 @@ abstract class AbstractCheck {
 /// commands.addCommand(ChatCommand(
 ///   'test',
 ///   'A test command',
-///   (IChatContext context) => context.respond(MessageBuilder.content('Hi there!')),
+///   (ChatContext context) => context.respond(MessageBuilder.content('Hi there!')),
 ///   checks: [check],
 /// ));
 ///
@@ -175,7 +175,7 @@ class Check extends AbstractCheck {
   /// commands.addCommand(ChatCommand(
   ///   'test',
   ///   'A test command',
-  ///   (IChatContext context) => context.respond(MessageBuilder.content('Hi there!')),
+  ///   (ChatContext context) => context.respond(MessageBuilder.content('Hi there!')),
   /// ));
   ///
   /// commands.onCommandError.listen((error) {

--- a/lib/src/checks/cooldown.dart
+++ b/lib/src/checks/cooldown.dart
@@ -105,7 +105,7 @@ class _BucketEntry {
 /// commands.addCommand(ChatCommand(
 ///   'test',
 ///   'A test command',
-///   (IChatContext context) => context.respond(MessageBuilder.content('Hi there!')),
+///   (ChatContext context) => context.respond(MessageBuilder.content('Hi there!')),
 /// ));
 ///
 /// commands.onCommandError.listen((error) {

--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -21,7 +21,7 @@ import 'options.dart';
 /// ChatCommand test = ChatCommand.slashOnly(
 ///   'test',
 ///   'A test command',
-///   (IChatContext context) async {
+///   (ChatContext context) async {
 ///     context.respond(MessageBuilder.content('Hi there!'));
 ///   },
 /// );
@@ -204,7 +204,7 @@ class ChatGroup with ChatGroupMixin, ParentMixin<ChatContext>, CheckMixin<ChatCo
 /// ChatCommand test = ChatCommand(
 ///   'test',
 ///   'A test command',
-///   (IChatContext context) async {
+///   (ChatContext context) async {
 ///     context.respond(MessageBuilder.content('Hi there!'));
 ///   },
 /// );

--- a/lib/src/commands/interfaces.dart
+++ b/lib/src/commands/interfaces.dart
@@ -92,7 +92,7 @@ abstract class CommandRegisterable<T extends CommandContext> implements CallHook
   ///  'hi',
   ///  'A test command',
   ///  (
-  ///   IChatContext context,
+  ///   ChatContext context,
   ///   @Name('message', {Locale.german: 'hallo'}) String foo,
   ///  ) async => context.respond(MessageBuilder.content(foo))
   /// );
@@ -189,7 +189,7 @@ abstract class ChatCommandComponent implements CommandRegisterable<ChatContext>,
   /// ChatCommand test = ChatCommand(
   ///   'test',
   ///   'A test command',
-  ///   (IChatContext context) async {
+  ///   (ChatContext context) async {
   ///     context.respond(MessageBuilder.content('Hi there!'));
   ///   },
   ///   aliases: ['t'],
@@ -213,7 +213,7 @@ abstract class ChatCommandComponent implements CommandRegisterable<ChatContext>,
   ///  'hi',
   ///  'A test command',
   ///   (
-  ///     IChatContext context,
+  ///     ChatContext context,
   ///     @Description('This is a description', {Locale.german: 'Dies ist eine Beschreibung'})
   ///         String foo,
   ///   ) async {

--- a/lib/src/converters/converter.dart
+++ b/lib/src/converters/converter.dart
@@ -30,6 +30,7 @@ import 'built_in.dart';
 /// - [textGuildChannelConverter], which converts [GuildTextChannel]s;
 /// - [voiceGuildChannelConverter], which converts [GuildVoiceChannel]s;
 /// - [stageVoiceChannelConverter], which converts [GuildStageChannel]s;
+/// - [categoryGuildChannelConverter], which converts [GuildCategory]s;
 /// - [roleConverter], which converts [Role]s;
 /// - [mentionableConverter], which converts [CommandOptionMentionable]s;
 /// - [attachmentConverter], which converts [Attachment]s.

--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -101,7 +101,7 @@ mixin InteractiveMixin implements InteractiveContext, ContextData {
     if (parent == null) {
       // This generally happens when a context is created directly from the plugin's context manager
       // and not from an existing context inside a command, which messes with functionality like
-      // parsing which requires an ICommandContext to invoke converters.
+      // parsing which requires an CommandContext to invoke converters.
       throw CommandsError(
         'Cannot use command functionality in a context created outside of a command',
       );

--- a/lib/src/util/util.dart
+++ b/lib/src/util/util.dart
@@ -36,7 +36,7 @@ String convertToKebabCase(String camelCase) {
 /// ChatCommand test = ChatCommand(
 ///   'test',
 ///   'A test command',
-///   (IChatContext context, String message) async {
+///   (ChatContext context, String message) async {
 ///     context.respond(MessageBuilder.content(message));
 ///   },
 /// );
@@ -49,7 +49,7 @@ String convertToKebabCase(String camelCase) {
 ///   'test',
 ///   'A test command',
 ///   (
-///     IChatContext context,
+///     ChatContext context,
 ///     @Description('The message to send') String message,
 ///   ) async {
 ///     context.respond(MessageBuilder.content(message));
@@ -72,7 +72,7 @@ class Description {
   ///  'hi',
   ///  'A test command',
   ///   (
-  ///     IChatContext context,
+  ///     ChatContext context,
   ///     @Description('This is a description', {Locale.german: 'Dies ist eine Beschreibung'})
   ///         String foo,
   ///   ) async {
@@ -106,7 +106,7 @@ class Description {
 ///   'test',
 ///   'A test command',
 ///   (
-///     IChatContext context,
+///     ChatContext context,
 ///     @Choices({'Foo': 'foo', 'Bar': 'bar', 'Baz': 'baz'}) String message,
 ///   ) async {
 ///     context.respond(MessageBuilder.content(message));
@@ -150,7 +150,7 @@ class Choices {
 ///   'test',
 ///   'A test command',
 ///   (
-///     IChatContext context,
+///     ChatContext context,
 ///     @Name('message') String foo,
 ///   ) async {
 ///     context.respond(MessageBuilder.content(foo));
@@ -171,7 +171,7 @@ class Name {
   ///  'hi',
   ///  'A test command',
   ///  (
-  ///   IChatContext context,
+  ///   ChatContext context,
   ///   @Name('message', {Locale.german: 'hallo'}) String foo,
   ///  ) async => context.respond(MessageBuilder.content(foo))
   /// );
@@ -218,7 +218,7 @@ class UseConverter {
 ///   'test',
 ///   'A test command',
 ///   (
-///     IChatContext context,
+///     ChatContext context,
 ///     @Autocomplete(foo) String bar,
 ///   ) async {
 ///     context.respond(MessageBuilder.content(bar));


### PR DESCRIPTION
# Description
This pull request updates the documentation and code comments throughout the codebase to consistently use `ChatContext` instead of the deprecated `IChatContext` in all examples and references. Additionally, it adds a missing documentation entry for the `categoryGuildChannelConverter`.

Documentation and comment consistency improvements:

* Replaced all occurrences of `IChatContext` with `ChatContext` in code examples and documentation comments across multiple files, including `README.md`, `example/example.dart`, `lib/src/checks/checks.dart`, `lib/src/checks/cooldown.dart`, `lib/src/commands/chat_command.dart`, `lib/src/commands/interfaces.dart`, and `lib/src/util/util.dart`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R62) [[3]](diffhunk://#diff-e30b82ca6132dc2e1109da46c81bf0a3e648a4efc0d9ba8c23e1e16624551127L112-R118) [[4]](diffhunk://#diff-e30b82ca6132dc2e1109da46c81bf0a3e648a4efc0d9ba8c23e1e16624551127L491-R491) [[5]](diffhunk://#diff-d520eb6a84fc5cc626b6bd84b93930ede8cb9ad70ce4de5a75edb7b1b7cde1d5L107-R107) [[6]](diffhunk://#diff-d520eb6a84fc5cc626b6bd84b93930ede8cb9ad70ce4de5a75edb7b1b7cde1d5L178-R178) [[7]](diffhunk://#diff-ae72d69bb2ea978532797bbcb5661c2676902aa11f5797c971334780d6ae7d82L108-R108) [[8]](diffhunk://#diff-4f5aa31a0550a6aea6925d4f429371ad1dd6bbf2948bc014485c4638cad76979L24-R24) [[9]](diffhunk://#diff-4f5aa31a0550a6aea6925d4f429371ad1dd6bbf2948bc014485c4638cad76979L207-R207) [[10]](diffhunk://#diff-c59fe0f534954fda4819c54e18a05b1971527129fecd76453bb9c427ab535361L95-R95) [[11]](diffhunk://#diff-c59fe0f534954fda4819c54e18a05b1971527129fecd76453bb9c427ab535361L192-R192) [[12]](diffhunk://#diff-c59fe0f534954fda4819c54e18a05b1971527129fecd76453bb9c427ab535361L216-R216) [[13]](diffhunk://#diff-7bb01f261135b91bd35db1a2835476d6f4d054977c7d65113007810ad8ccc923L39-R39) [[14]](diffhunk://#diff-7bb01f261135b91bd35db1a2835476d6f4d054977c7d65113007810ad8ccc923L52-R52) [[15]](diffhunk://#diff-7bb01f261135b91bd35db1a2835476d6f4d054977c7d65113007810ad8ccc923L75-R75) [[16]](diffhunk://#diff-7bb01f261135b91bd35db1a2835476d6f4d054977c7d65113007810ad8ccc923L109-R109) [[17]](diffhunk://#diff-7bb01f261135b91bd35db1a2835476d6f4d054977c7d65113007810ad8ccc923L153-R153) [[18]](diffhunk://#diff-7bb01f261135b91bd35db1a2835476d6f4d054977c7d65113007810ad8ccc923L174-R174) [[19]](diffhunk://#diff-7bb01f261135b91bd35db1a2835476d6f4d054977c7d65113007810ad8ccc923L221-R221)
* Updated a comment in `lib/src/util/mixins.dart` to reference `CommandContext` instead of `ICommandContext`.

Documentation enhancements:

* Added a documentation entry for `categoryGuildChannelConverter` to the list of available converters in `lib/src/converters/converter.dart`.

<!-- ## Connected issues & other potential problems

If changes in PR are connected to other issues or are affecting code in other parts of framework
(e.g. in main package or any other subpackage) make sure to link issue/PR and describe said problem.

Uncomment this part to add context if needed.
-->

## Type of change
- [x] Documentation

<!-- 
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Move/Copy lines that apply out of the comment.
-->

## Checklist:
- [x] Ran `dart analyze` _(no issues related to my changes)_
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib`
- [x] I have made corresponding changes to the documentation (literally)
- [ ] I have added tests that prove my fix is effective or that my feature works _(no applicable tests)_
